### PR TITLE
Patch 1

### DIFF
--- a/Templates/New-SetupConfigINI.ps1
+++ b/Templates/New-SetupConfigINI.ps1
@@ -122,7 +122,7 @@ $main = {
                 }
                 Catch {
                     #reading the file threw an error.  Seen this with blankish files.  Just delete it and rewrite.
-                    Remove-Item $SourceIniFile
+                    Remove-Item $SourceIniFile -force
                 }
         }
 

--- a/Templates/New-SetupConfigINI.ps1
+++ b/Templates/New-SetupConfigINI.ps1
@@ -117,7 +117,13 @@ $main = {
 
         #Get contents of the current INI File.
         If (Test-Path -Path $SourceIniFile -ErrorAction SilentlyContinue) {
-            $CurrrentIniFileContent = Parse-IniFile -IniFile $SourceIniFile
+                Try {
+                    $CurrrentIniFileContent = Parse-IniFile -IniFile $SourceIniFile
+                }
+                Catch {
+                    #reading the file threw an error.  Seen this with blankish files.  Just delete it and rewrite.
+                    Remove-Item $SourceIniFile
+                }
         }
 
         #If the current file has valid content and we aren't forcing a re-write, check the contents against the expected values.


### PR DESCRIPTION
Seems like on some blank files, it is still throwing an error when trying to parse the INI file.  `$CurrrentIniFileContent = Parse-IniFile -IniFile $SourceIniFile`

I propose a change to add a try/catch block.  If it can't parse the ini file, then just delete it from there, then it will recreate it with desired settings.

I've been running with this modification now for a few days and can confirm that the systems that were erroring out on my baseline cleared themselves up.